### PR TITLE
Add `my_map`.

### DIFF
--- a/bench/my_map_bench.exs
+++ b/bench/my_map_bench.exs
@@ -6,6 +6,8 @@ Benchee.run %{time: 10, warmup: 10}, [
    fn -> MyMap.map_tco(list, map_fun) end},
   {"map with TCO reverse new acc",
    fn -> MyMap.map_tco_new_acc(list, map_fun) end},
+  {"my_map",
+   fn -> MyMap.my_map(list, map_fun) end},
   {"map with TCO and ++",
    fn -> MyMap.map_tco_concat(list, map_fun) end},
   {"map simple without TCO",

--- a/lib/my_map.ex
+++ b/lib/my_map.ex
@@ -32,6 +32,21 @@ defmodule MyMap do
   end
 
   @doc """
+  iex> MyMap.my_map [1, 2, 3, 4], fn(i) -> i + 1 end
+  [2, 3, 4, 5]
+  """
+  def my_map(list, fun) do
+    do_my_map(list, fun, [])
+  end
+  defp do_my_map([], _fun, acc) do
+    Enum.reverse acc
+  end
+  defp do_my_map([head | tail], fun, acc) do
+    new_acc = [fun.(head) | acc]
+    do_my_map(tail, fun, new_acc)
+  end
+
+  @doc """
   iex> MyMap.map_tco_concat [1, 2, 3, 4], fn(i) -> i + 1 end
   [2, 3, 4, 5]
   """


### PR DESCRIPTION
Findings from running the benchmark multiple times are interesting:

```
➜  elixir_playground git:(pd-my_map) ✗ mix run bench/my_map_bench.exs        # 1

Name                                    ips        average    deviation         median
my_map                              4500.03       222.22μs    (±20.66%)       201.00μs
map simple without TCO              3846.15       260.00μs    (±18.51%)       241.00μs
stdlib map                          3819.47       261.82μs    (±18.24%)       246.00μs
map TCO no reverse                  3588.02       278.71μs    (±16.81%)       260.00μs
map with TCO reverse new acc        3226.76       309.91μs    (±18.36%)       287.00μs
map with TCO reverse                2958.96       337.96μs    (±20.70%)       322.00μs
map with TCO and ++                    4.93    202787.47μs     (±5.27%)    202104.00μs

Comparison:
my_map                              4500.03
map simple without TCO              3846.15 - 1.17x slower
stdlib map                          3819.47 - 1.18x slower
map TCO no reverse                  3588.02 - 1.25x slower
map with TCO reverse new acc        3226.76 - 1.39x slower
map with TCO reverse                2958.96 - 1.52x slower
map with TCO and ++                    4.93 - 912.55x slower

➜  elixir_playground git:(pd-my_map) ✗ mix run bench/my_map_bench.exs        # 2

Name                                    ips        average    deviation         median
my_map                              4520.12       221.23μs    (±19.26%)       201.00μs
stdlib map                          3830.82       261.04μs    (±17.20%)       245.00μs
map simple without TCO              3770.27       265.23μs    (±18.16%)       246.00μs
map TCO no reverse                  3523.43       283.81μs    (±18.66%)       263.00μs
map with TCO reverse new acc        3225.41       310.04μs    (±16.91%)       291.00μs
map with TCO reverse                2959.59       337.88μs    (±20.17%)       323.00μs
map with TCO and ++                    4.90    204177.29μs     (±5.65%)    202454.00μs

Comparison:
my_map                              4520.12
stdlib map                          3830.82 - 1.18x slower
map simple without TCO              3770.27 - 1.20x slower
map TCO no reverse                  3523.43 - 1.28x slower
map with TCO reverse new acc        3225.41 - 1.40x slower
map with TCO reverse                2959.59 - 1.53x slower
map with TCO and ++                    4.90 - 922.91x slower

➜  elixir_playground git:(pd-my_map) ✗ mix run bench/my_map_bench.exs        # 3

Name                                    ips        average    deviation         median
map simple without TCO              3842.86       260.22μs    (±17.52%)       244.00μs
stdlib map                          3803.35       262.93μs    (±17.86%)       246.00μs
my_map                              3551.61       281.56μs    (±18.70%)       272.00μs
map TCO no reverse                  3507.86       285.07μs    (±18.33%)       264.00μs
map with TCO reverse new acc        3209.12       311.61μs    (±17.80%)       292.00μs
map with TCO reverse                2942.35       339.86μs    (±20.30%)       325.00μs
map with TCO and ++                    4.40    227155.57μs     (±4.99%)    226657.50μs

Comparison:
map simple without TCO              3842.86
stdlib map                          3803.35 - 1.01x slower
my_map                              3551.61 - 1.08x slower
map TCO no reverse                  3507.86 - 1.10x slower
map with TCO reverse new acc        3209.12 - 1.20x slower
map with TCO reverse                2942.35 - 1.31x slower
map with TCO and ++                    4.40 - 872.93x slower

➜  elixir_playground git:(pd-my_map) ✗ mix run bench/my_map_bench.exs        # 4

Name                                    ips        average    deviation         median
stdlib map                          3843.06       260.21μs    (±17.37%)       245.00μs
map simple without TCO              3834.99       260.76μs    (±18.08%)       242.00μs
my_map                              3590.95       278.48μs    (±18.87%)       266.00μs
map TCO no reverse                  3495.17       286.11μs    (±19.45%)       264.00μs
map with TCO reverse new acc        3257.41       306.99μs    (±17.12%)       290.00μs
map with TCO reverse                3022.98       330.80μs    (±19.11%)       321.00μs
map with TCO and ++                    4.38    228513.00μs     (±4.69%)    227483.00μs

Comparison:
stdlib map                          3843.06
map simple without TCO              3834.99 - 1.00x slower
my_map                              3590.95 - 1.07x slower
map TCO no reverse                  3495.17 - 1.10x slower
map with TCO reverse new acc        3257.41 - 1.18x slower
map with TCO reverse                3022.98 - 1.27x slower
map with TCO and ++                    4.38 - 878.19x slower

➜  elixir_playground git:(pd-my_map) ✗ mix run bench/my_map_bench.exs        # 5

Name                                    ips        average    deviation         median
map simple without TCO              3851.92       259.61μs    (±18.11%)       242.00μs
stdlib map                          3768.32       265.37μs    (±19.42%)       249.00μs
my_map                              3570.36       280.08μs    (±19.20%)       268.00μs
map TCO no reverse                  3536.31       282.78μs    (±17.87%)       264.00μs
map with TCO reverse new acc        3262.10       306.55μs    (±17.37%)       287.00μs
map with TCO reverse                2964.26       337.35μs    (±20.94%)       322.00μs
map with TCO and ++                    4.32    231627.35μs     (±5.24%)    231257.00μs

Comparison:
map simple without TCO              3851.92
stdlib map                          3768.32 - 1.02x slower
my_map                              3570.36 - 1.08x slower
map TCO no reverse                  3536.31 - 1.09x slower
map with TCO reverse new acc        3262.10 - 1.18x slower
map with TCO reverse                2964.26 - 1.30x slower
map with TCO and ++                    4.32 - 892.21x slower

➜  elixir_playground git:(pd-my_map) ✗ mix run bench/my_map_bench.exs        # 6

Name                                    ips        average    deviation         median
stdlib map                          3810.34       262.44μs    (±18.65%)       245.00μs
map simple without TCO              3804.62       262.84μs    (±18.69%)       244.00μs
map TCO no reverse                  3559.50       280.94μs    (±17.11%)       265.00μs
my_map                              3502.92       285.48μs    (±21.22%)       271.00μs
map with TCO reverse new acc        3129.70       319.52μs    (±20.10%)       297.00μs
map with TCO reverse                2903.64       344.40μs    (±22.63%)       326.00μs
map with TCO and ++                    4.40    227039.64μs     (±6.02%)    225895.50μs

Comparison:
stdlib map                          3810.34
map simple without TCO              3804.62 - 1.00x slower
map TCO no reverse                  3559.50 - 1.07x slower
my_map                              3502.92 - 1.09x slower
map with TCO reverse new acc        3129.70 - 1.22x slower
map with TCO reverse                2903.64 - 1.31x slower
map with TCO and ++                    4.40 - 865.10x slower

➜  elixir_playground git:(pd-my_map) ✗ mix run bench/my_map_bench.exs        # 7

Name                                    ips        average    deviation         median
map simple without TCO              3850.72       259.69μs    (±17.40%)       243.00μs
stdlib map                          3769.69       265.27μs    (±19.38%)       248.00μs
my_map                              3535.64       282.83μs    (±20.51%)       268.00μs
map TCO no reverse                  3509.91       284.91μs    (±19.00%)       263.00μs
map with TCO reverse new acc        3192.04       313.28μs    (±19.69%)       292.00μs
map with TCO reverse                2956.61       338.22μs    (±20.88%)       323.00μs
map with TCO and ++                    4.36    229280.74μs     (±6.52%)    227199.00μs

Comparison:
map simple without TCO              3850.72
stdlib map                          3769.69 - 1.02x slower
my_map                              3535.64 - 1.09x slower
map TCO no reverse                  3509.91 - 1.10x slower
map with TCO reverse new acc        3192.04 - 1.21x slower
map with TCO reverse                2956.61 - 1.30x slower
map with TCO and ++                    4.36 - 882.90x slower

➜  elixir_playground git:(pd-my_map) ✗ mix run bench/my_map_bench.exs        # 8

Name                                    ips        average    deviation         median
stdlib map                          3767.87       265.40μs    (±19.52%)       249.00μs
map simple without TCO              3762.97       265.75μs    (±20.00%)       245.00μs
my_map                              3557.41       281.10μs    (±19.60%)       268.00μs
map TCO no reverse                  3518.75       284.19μs    (±18.87%)       263.00μs
map with TCO reverse new acc        3192.42       313.24μs    (±19.44%)       292.00μs
map with TCO reverse                2989.33       334.52μs    (±20.20%)       322.00μs
map with TCO and ++                    4.39    227951.35μs     (±5.48%)    228356.00μs

Comparison:
stdlib map                          3767.87
map simple without TCO              3762.97 - 1.00x slower
my_map                              3557.41 - 1.06x slower
map TCO no reverse                  3518.75 - 1.07x slower
map with TCO reverse new acc        3192.42 - 1.18x slower
map with TCO reverse                2989.33 - 1.26x slower
map with TCO and ++                    4.39 - 858.89x slower
```

For the runs #1 and #2, `my_lib` seems to perform very well (with ips
`~4500`), but for the rest of them, it falls to `3502-3590` (even trying to
run the benchmark couple more times didn't cause to reproduce great
result of `4500`).

What is really interesting, "map with TCO reverse new acc" seems to be
slower from `my_map` by about `260-440` (with ips ranging from `3129` to `3262`).

Comparing "stdlib map" and "map simple without TCO" rather indicates
they are about equally performant -> 50% of benchmarks indicate "stdlib
map" is faster and the other 50%, where "map simple without TCO" with ips
differences ranging from `5 - ~80`.

Final thing worth taking a look at is comparing `my_map` to "map with
TCO reverse", which is quicker by `~570 - ~610` ips', proving there is no
compilation optimisation happening and it requires a bit more attention
when aiming for TCO.
